### PR TITLE
Removed closing PHP tags from RenderType files

### DIFF
--- a/library/SSRS/RenderType/RenderAsCSV.php
+++ b/library/SSRS/RenderType/RenderAsCSV.php
@@ -106,5 +106,3 @@ class RenderAsCSV extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderAsEXCEL.php
+++ b/library/SSRS/RenderType/RenderAsEXCEL.php
@@ -70,5 +70,3 @@ class RenderAsEXCEL extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderAsHTML.php
+++ b/library/SSRS/RenderType/RenderAsHTML.php
@@ -148,5 +148,3 @@ class RenderAsHTML extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderAsIMAGE.php
+++ b/library/SSRS/RenderType/RenderAsIMAGE.php
@@ -136,5 +136,3 @@ class RenderAsIMAGE extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderAsMHTML.php
+++ b/library/SSRS/RenderType/RenderAsMHTML.php
@@ -64,5 +64,3 @@ class RenderAsMHTML extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderAsPDF.php
+++ b/library/SSRS/RenderType/RenderAsPDF.php
@@ -120,6 +120,4 @@ class RenderAsPDF extends RenderBaseType implements IRenderType {
     }
 }
 
-?>
-
 

--- a/library/SSRS/RenderType/RenderAsWORD.php
+++ b/library/SSRS/RenderType/RenderAsWORD.php
@@ -82,5 +82,3 @@ class RenderAsWORD extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderAsXML.php
+++ b/library/SSRS/RenderType/RenderAsXML.php
@@ -101,5 +101,3 @@ class RenderAsXML extends RenderBaseType implements IRenderType {
         return parent::GetDevInfoXML_Base($this);
     }
 }
-
-?>

--- a/library/SSRS/RenderType/RenderBaseType.php
+++ b/library/SSRS/RenderType/RenderBaseType.php
@@ -58,5 +58,3 @@ class RenderBaseType {
         return $retXML;
     }
 }
-
-?>


### PR DESCRIPTION
Removed closing PHP tags and whitespace from RenderType files to prevent "headers already sent" warnings.

[Warning: Cannot modify header information - headers already sent](https://stackoverflow.com/questions/8028957/how-to-fix-headers-already-sent-error-in-php)